### PR TITLE
Don't do travis_retry for tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ env:
 install:
   - travis_retry pip install tox==1.6.1
 script:
-  - travis_retry tox
+  - tox


### PR DESCRIPTION
because tests can fail deterministically and retrying doesn't help and
just makes the tests take longer to fail.
